### PR TITLE
Allow ConverterList creation via basic Reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ use Org_Heigl\HtmlToPdflib\Converter\Strong;
 use Org_Heigl\HtmlToPdflib\Converter\Ul;
 use Org_Heigl\HtmlToPdflib\Factory;
 
-$converter = new Converter(Factory::fromConverterList(new ConverterList([
+$converter = new Converter(Factory::fromConverterList(ConverterList::createViaReflection([
     'em' => Em::class,
     'li' => Li::class,
     'ol' => Ol::class,

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,10 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "ext-dom": "*",
-        "roave/better-reflection": "^4.9"
+        "ext-dom": "*"
+    },
+    "suggest": {
+        "roave/better-reflection": "For using ConverterList::createViaBetterReflection"
     },
     "autoload" : {
         "psr-4" : {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -2,7 +2,7 @@
 
 /**
  * Copyright (c) Andreas Heigl<andreas@heigl.org>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -12,7 +12,7 @@
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -57,7 +57,7 @@ final class Factory
 
     public static function withDefaultConverters(): self
     {
-        return new self(new ConverterList([
+        return new self(ConverterList::createViaReflection([
             'em' => Em::class,
             'li' => Li::class,
             'ol' => Ol::class,
@@ -93,4 +93,4 @@ final class Factory
         }
         return new Standard($node, $converter);
     }
-} 
+}

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -29,7 +29,7 @@ class ConverterTest extends TestCase
 
     public function testExtendedSetup(): void
     {
-        $converter = new Converter(Factory::fromConverterList(new ConverterList([
+        $converter = new Converter(Factory::fromConverterList(ConverterList::createViaReflection([
             'em'     => Converter\Em::class,
             'li'     => Converter\Li::class,
             'ol'     => Converter\Ol::class,


### PR DESCRIPTION
This way users can decide whether to use BetterReflection or the
build-in Reflection-API for checking the ConverterList.

This is a BC break as the instantiation of the ConverterList has
changed.

This fixes #3 