### PR TITLE
allow custom delimiters to be passed into the converter

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -40,6 +40,9 @@ class Converter
     /** @var Factory */
     private $factory;
 
+    protected $leftMacroDelimiter = '<';
+    protected $rightMacroDelimiter = '>';
+
     public function __construct(Factory $factory = null)
     {
         if (null === $factory) {
@@ -54,6 +57,31 @@ class Converter
         $dom = new DOMDocument('1.0', 'UTF-8');
         $dom->loadHTML('<?xml encoding="UTF-8">' . $text);
 
-        return $this->factory->getConverterForTag($dom->documentElement)->getPdflibString();
+        return $this->
+            factory->
+            getConverterForTag($dom->documentElement)->
+            setLeftDelimiter($this->leftMacroDelimiter)->
+            setRightDelimiter($this->rightMacroDelimiter)->
+            getPdflibString();
+
     }
+
+    public function setLeftMacroDelimiter($p_delimiter = '<') {
+        if($this->validateDelimiter($p_delimiter)) $this->leftMacroDelimiter = $p_delimiter;
+    }
+
+    public function setRightMacroDelimiter($p_delimiter = '>') {
+        if($this->validateDelimiter($p_delimiter)) $this->rightMacroDelimiter = $p_delimiter;
+    }
+
+    private function validateDelimiter($p_delimiter) {
+        // delimiter must be a single character
+        //
+        if(strlen($p_delimiter) == 1) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
 }

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -43,13 +43,17 @@ class Converter
     protected $leftMacroDelimiter = '<';
     protected $rightMacroDelimiter = '>';
 
-    public function __construct(Factory $factory = null)
+    public function __construct(Factory $factory = null, $leftMacroDelimiter = '<', $rightMacroDelimiter = '>')
     {
         if (null === $factory) {
             $factory = Factory::withDefaultConverters();
         }
         
         $this->factory = $factory;
+
+        if($this->validateDelimiter($leftMacroDelimiter)) $this->leftMacroDelimiter = $leftMacroDelimiter;
+        if($this->validateDelimiter($rightMacroDelimiter)) $this->rightMacroDelimiter = $rightMacroDelimiter;
+
     }
 
     public function convert($text)
@@ -59,19 +63,9 @@ class Converter
 
         return $this->
             factory->
-            getConverterForTag($dom->documentElement)->
-            setLeftDelimiter($this->leftMacroDelimiter)->
-            setRightDelimiter($this->rightMacroDelimiter)->
+            getConverterForTag($dom->documentElement, null, $this->leftMacroDelimiter, $this->rightMacroDelimiter)->
             getPdflibString();
 
-    }
-
-    public function setLeftMacroDelimiter($p_delimiter = '<') {
-        if($this->validateDelimiter($p_delimiter)) $this->leftMacroDelimiter = $p_delimiter;
-    }
-
-    public function setRightMacroDelimiter($p_delimiter = '>') {
-        if($this->validateDelimiter($p_delimiter)) $this->rightMacroDelimiter = $p_delimiter;
     }
 
     private function validateDelimiter($p_delimiter) {
@@ -79,8 +73,6 @@ class Converter
         //
         if(strlen($p_delimiter) == 1) {
             return true;
-        } else {
-            return false;
         }
     }
 

--- a/src/Converter/Standard.php
+++ b/src/Converter/Standard.php
@@ -55,18 +55,13 @@ class Standard implements ConverterInterface
     protected $rightDelimiter = '>';
 
 
-    public function __construct(DOMNode $node, ConverterInterface $parentConverter = null)
+    public function __construct(DOMNode $node, ConverterInterface $parentConverter = null, $leftDelimiter = '<', $rightDelimiter = '>')
     {
         $this->node = $node;
         $this->parentConverter = $parentConverter;
 
-        // use the delimiters from the parent, if one is present
-        //
-        if($this->parentConverter) {
-            $this->leftDelimiter = $this->parentConverter->leftDelimiter;
-            $this->rightDelimiter = $this->parentConverter->rightDelimiter;
-        }
-
+        $this->leftDelimiter = $leftDelimiter;
+        $this->rightDelimiter = $rightDelimiter;
     }
 
     public function getPdfLibString()
@@ -90,7 +85,7 @@ class Standard implements ConverterInterface
             return $node->textContent;
         }
 
-        return Factory::factory($node, $this)->getPdfLibString();
+        return Factory::factory($node, $this, $this->leftDelimiter, $this->rightDelimiter)->getPdfLibString();
     }
 
     public function getMacro()
@@ -123,16 +118,6 @@ class Standard implements ConverterInterface
     public function getPreviousConverter()
     {
         return $this->parentConverter;
-    }
-
-    public function setLeftDelimiter($p_delimiter) {
-        $this->leftDelimiter = $p_delimiter;
-        return $this;
-    }
-
-    public function setRightDelimiter($p_delimiter) {
-        $this->rightDelimiter = $p_delimiter;
-        return $this;
     }
 
 }

--- a/src/Converter/Standard.php
+++ b/src/Converter/Standard.php
@@ -50,10 +50,23 @@ class Standard implements ConverterInterface
 
     protected $postfix = '';
 
+    protected $leftDelimiter = '<';
+
+    protected $rightDelimiter = '>';
+
+
     public function __construct(DOMNode $node, ConverterInterface $parentConverter = null)
     {
         $this->node = $node;
         $this->parentConverter = $parentConverter;
+
+        // use the delimiters from the parent, if one is present
+        //
+        if($this->parentConverter) {
+            $this->leftDelimiter = $this->parentConverter->leftDelimiter;
+            $this->rightDelimiter = $this->parentConverter->rightDelimiter;
+        }
+
     }
 
     public function getPdfLibString()
@@ -85,7 +98,7 @@ class Standard implements ConverterInterface
         if (! $this->macro) {
             return '';
         }
-        $macro = '<&' . $this->macro . '>';
+        $macro = $this->leftDelimiter . '&' . $this->macro . $this->rightDelimiter;
 
         if ($macro == $this->getPreviousMacro()) {
             return '';
@@ -111,4 +124,15 @@ class Standard implements ConverterInterface
     {
         return $this->parentConverter;
     }
+
+    public function setLeftDelimiter($p_delimiter) {
+        $this->leftDelimiter = $p_delimiter;
+        return $this;
+    }
+
+    public function setRightDelimiter($p_delimiter) {
+        $this->rightDelimiter = $p_delimiter;
+        return $this;
+    }
+
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -75,26 +75,26 @@ final class Factory
      *
      * @return ConverterInterface
      */
-    public static function factory(DOMNode $node, ConverterInterface $converter = null)
+    public static function factory(DOMNode $node, ConverterInterface $converter = null, $leftDelimiter = '<', $rightDelimiter = '>')
     {
         if (!self::$factory instanceof self) {
             self::$factory = self::withDefaultConverters();
         }
 
-        return self::$factory->getConverterForTag($node, $converter);
+        return self::$factory->getConverterForTag($node, $converter, $leftDelimiter, $rightDelimiter);
     }
 
-    public function getConverterForTag(DOMNode $node, ConverterInterface $converter = null): ConverterInterface
+    public function getConverterForTag(DOMNode $node, ConverterInterface $converter = null, $leftDelimiter = '<', $rightDelimiter = '>'): ConverterInterface
     {
         $tagName = $node->nodeName;
 
         try {
             $converterClass = $this->converterList->getConverterForTag($tagName);
-            return new $converterClass($node, $converter);
+            return new $converterClass($node, $converter, $leftDelimiter, $rightDelimiter);
 
         } catch (\Exception $e) {
             // Do nothing on purpose
         }
-        return new Standard($node, $converter);
+        return new Standard($node, $converter, $leftDelimiter, $rightDelimiter);
     }
 }


### PR DESCRIPTION
Re issue #7 - allow macro delimiters to be overridden.

Two new public methods - setLeftMacroDelimiter and setRightMacroDelimiter - can be used to set the delimiters before conversion.

